### PR TITLE
Specify baseUrl using .env variable

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,7 +30,9 @@
                 'csrfToken' => csrf_token(),
         ]); ?>;
 
-        var baseUrl = "<?php echo secure_url('/'); ?>";
+        // var baseUrl = "<?php echo secure_url('/'); ?>";
+        baseUrl = "<?php echo env('APP_URL') . '/'; ?>";
+        
     </script>
 
     <!-- Select 2 -->


### PR DESCRIPTION
Javascript not working when tested on http:// installation. Requires https://. This is determined by `baseUrl`. which is set by secure_url(). Suggest that this is instead set using the APP_URL constant in the .env file. 